### PR TITLE
Make transformation dict independent to coordsys

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -620,7 +620,7 @@ class Basic(metaclass=ManagedProperties):
             reps[v] = d
         return reps
 
-    def rcall(self, *args):
+    def rcall(self, *args, **kwargs):
         """Apply on the argument recursively through the expression tree.
 
         This method is used to simulate a common abuse of notation for
@@ -635,10 +635,10 @@ class Basic(metaclass=ManagedProperties):
         >>> (x + Lambda(y, 2*y)).rcall(z)
         x + 2*z
         """
-        return Basic._recursive_call(self, args)
+        return Basic._recursive_call(self, args, kwargs)
 
     @staticmethod
-    def _recursive_call(expr_to_call, on_args):
+    def _recursive_call(expr_to_call, on_args, on_kwargs):
         """Helper for rcall method."""
         from sympy import Symbol
         def the_call_method_is_overridden(expr):
@@ -650,10 +650,10 @@ class Basic(metaclass=ManagedProperties):
             if isinstance(expr_to_call, Symbol):  # XXX When you call a Symbol it is
                 return expr_to_call               # transformed into an UndefFunction
             else:
-                return expr_to_call(*on_args)
+                return expr_to_call(*on_args, **on_kwargs)
         elif expr_to_call.args:
             args = [Basic._recursive_call(
-                sub, on_args) for sub in expr_to_call.args]
+                sub, on_args, on_kwargs) for sub in expr_to_call.args]
             return type(expr_to_call)(*args)
         else:
             return expr_to_call

--- a/sympy/diffgeom/rn.py
+++ b/sympy/diffgeom/rn.py
@@ -11,22 +11,31 @@ using the usual `coord_sys.coord_function(index, name)` interface.
 from typing import Any
 
 from .diffgeom import Manifold, Patch, CoordSystem
-from sympy import sqrt, atan2, acos, sin, cos, Dummy, Lambda
+from sympy.core.symbol import Dummy, symbols
+from sympy.matrices import Matrix
+from sympy import sqrt, atan2, acos, sin, cos, Lambda
 
 __all__ = [
     'R2', 'R2_origin', 'R2_r', 'R2_p',
     'R3', 'R3_origin', 'R3_r', 'R3_c', 'R3_s'
 ]
 
+x, y = symbols('x y', cls=Dummy)
+r, t = symbols('rho theta', cls=Dummy)
+
 ###############################################################################
 # R2
 ###############################################################################
-x, y, r, theta = [Dummy(s) for s in ['x', 'y', 'r', 'theta']]
 R2 = Manifold('R^2', 2)  # type: Any
 # Patch and coordinate systems.
 R2_origin = Patch('origin', R2)  # type: Any
 R2_r = CoordSystem('rectangular', R2_origin, ['x', 'y'])  # type: Any
 R2_p = CoordSystem('polar', R2_origin, ['r', 'theta'])  # type: Any
+
+transforms_2d = {
+    (R2_r, R2_p): Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
+    (R2_p, R2_r): Lambda((r, t), Matrix([r*cos(t), r*sin(t)])),
+}
 
 # Defining the basis coordinate functions and adding shortcuts for them to the
 # manifold and the patch.
@@ -46,14 +55,42 @@ R2.dr, R2.dtheta = R2_origin.dr, R2_origin.dtheta = R2_p.dr, R2_p.dtheta = R2_p.
 ###############################################################################
 # R3
 ###############################################################################
-x, y, z, rho, psi, r, theta, phi = [Dummy(s) for s in ['x', 'y', 'z',
-                                          'rho', 'psi', 'r', 'theta', 'phi']]
 R3 = Manifold('R^3', 3)  # type: Any
 # Patch and coordinate systems.
 R3_origin = Patch('origin', R3)  # type: Any
 R3_r = CoordSystem('rectangular', R3_origin, ['x', 'y', 'z'])  # type: Any
 R3_c = CoordSystem('cylindrical', R3_origin, ['rho', 'psi', 'z'],)  # type: Any
 R3_s = CoordSystem('spherical', R3_origin, ['r', 'theta', 'phi'],)  # type: Any
+
+x, y, z = symbols('x y z', cls=Dummy)
+r, t, p = symbols('rho theta phi', cls=Dummy)
+
+transforms_3d = {
+    (R3_r, R3_c):
+        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2), atan2(y, x), z])),
+    (R3_c, R3_r):
+        Lambda((r, p, z), Matrix([r*cos(p), r*sin(p), z])),
+    (R3_r, R3_s):
+        Lambda(
+            (x, y, z),
+            Matrix([
+                sqrt(x**2 + y**2 + z**2),
+                acos(z/sqrt(x**2 + y**2 + z**2)),
+                atan2(y, x)])
+        ),
+    (R3_s, R3_r):
+        Lambda(
+            (r, t, p),
+            Matrix([r*sin(t)*cos(p), r*sin(t)*sin(p), r*cos(t)])
+        ),
+    (R3_c, R3_s):
+        Lambda(
+            (r, p, z),
+            Matrix([sqrt(r**2 + z**2), acos(z/sqrt(r**2 + z**2)), p])
+        ),
+    (R3_s, R3_c):
+        Lambda((r, t, p), Matrix([r*sin(t), p, r*cos(t)])),
+}
 
 # Defining the basis coordinate functions.
 R3_r.x, R3_r.y, R3_r.z = R3_r.coord_functions()

--- a/sympy/diffgeom/rn.py
+++ b/sympy/diffgeom/rn.py
@@ -11,9 +11,11 @@ using the usual `coord_sys.coord_function(index, name)` interface.
 from typing import Any
 
 from .diffgeom import Manifold, Patch, CoordSystem
+from sympy.core.containers import Dict
 from sympy.core.symbol import Dummy, symbols
 from sympy.matrices import Matrix
 from sympy import sqrt, atan2, acos, sin, cos, Lambda
+
 
 __all__ = [
     'R2', 'R2_origin', 'R2_r', 'R2_p',
@@ -32,10 +34,10 @@ R2_origin = Patch('origin', R2)  # type: Any
 R2_r = CoordSystem('rectangular', R2_origin, ['x', 'y'])  # type: Any
 R2_p = CoordSystem('polar', R2_origin, ['r', 'theta'])  # type: Any
 
-transforms_2d = {
+transforms_2d = Dict({
     (R2_r, R2_p): Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
     (R2_p, R2_r): Lambda((r, t), Matrix([r*cos(t), r*sin(t)])),
-}
+})
 
 # Defining the basis coordinate functions and adding shortcuts for them to the
 # manifold and the patch.
@@ -65,7 +67,7 @@ R3_s = CoordSystem('spherical', R3_origin, ['r', 'theta', 'phi'],)  # type: Any
 x, y, z = symbols('x y z', cls=Dummy)
 r, t, p = symbols('rho theta phi', cls=Dummy)
 
-transforms_3d = {
+transforms_3d = Dict({
     (R3_r, R3_c):
         Lambda((x, y, z), Matrix([sqrt(x**2 + y**2), atan2(y, x), z])),
     (R3_c, R3_r):
@@ -90,7 +92,7 @@ transforms_3d = {
         ),
     (R3_s, R3_c):
         Lambda((r, t, p), Matrix([r*sin(t), p, r*cos(t)])),
-}
+})
 
 # Defining the basis coordinate functions.
 R3_r.x, R3_r.y, R3_r.z = R3_r.coord_functions()

--- a/sympy/diffgeom/rn.py
+++ b/sympy/diffgeom/rn.py
@@ -26,15 +26,7 @@ R2 = Manifold('R^2', 2)  # type: Any
 # Patch and coordinate systems.
 R2_origin = Patch('origin', R2)  # type: Any
 R2_r = CoordSystem('rectangular', R2_origin, ['x', 'y'])  # type: Any
-R2_p = CoordSystem(
-    'polar', R2_origin, ['r', 'theta'],
-    {
-        R2_r: (
-            Lambda((r, theta), [r*cos(theta), r*sin(theta)]),
-            Lambda((x, y), [sqrt(x**2 + y**2), atan2(y, x)])
-        )
-    }
-)  # type: Any
+R2_p = CoordSystem('polar', R2_origin, ['r', 'theta'])  # type: Any
 
 # Defining the basis coordinate functions and adding shortcuts for them to the
 # manifold and the patch.
@@ -60,28 +52,8 @@ R3 = Manifold('R^3', 3)  # type: Any
 # Patch and coordinate systems.
 R3_origin = Patch('origin', R3)  # type: Any
 R3_r = CoordSystem('rectangular', R3_origin, ['x', 'y', 'z'])  # type: Any
-R3_c = CoordSystem(
-    'cylindrical', R3_origin, ['rho', 'psi', 'z'],
-    {
-        R3_r: (
-            Lambda((rho, psi, z), [rho*cos(psi), rho*sin(psi), z]),
-            Lambda((x, y, z), [sqrt(x**2 + y**2), atan2(y, x), z])
-        )
-    }
-)  # type: Any
-R3_s = CoordSystem(
-    'spherical', R3_origin, ['r', 'theta', 'phi'],
-    {
-        R3_r: (
-            Lambda((r, theta, phi), [r*sin(theta)*cos(phi), r*sin(theta)*sin(phi), r*cos(theta)]),
-            Lambda((x, y, z), [sqrt(x**2 + y**2 + z**2), acos(z/sqrt(x**2 + y**2 + z**2)), atan2(y, x)])
-        ),
-        R3_c: (
-            Lambda((r, theta, phi), [r*sin(theta), phi, r*cos(theta)]),
-            Lambda((rho, psi, z), [sqrt(rho**2 + z**2), acos(z/sqrt(rho**2 + z**2)), psi])
-        )
-    }
-)  # type: Any
+R3_c = CoordSystem('cylindrical', R3_origin, ['rho', 'psi', 'z'],)  # type: Any
+R3_s = CoordSystem('spherical', R3_origin, ['r', 'theta', 'phi'],)  # type: Any
 
 # Defining the basis coordinate functions.
 R3_r.x, R3_r.y, R3_r.z = R3_r.coord_functions()

--- a/sympy/diffgeom/tests/test_class_structure.py
+++ b/sympy/diffgeom/tests/test_class_structure.py
@@ -20,16 +20,11 @@ def test_point():
     #TODO assert point.free_symbols == set([x, y])
 
 
-def test_atomicclass_args():
-    assert m.args == ()
-    assert p.args == ()
-    assert cs.args == ()
-    assert cs_noname.args == ()
-
 def test_rebuild():
     assert s1 == s1.func(*s1.args)
     assert v1 == v1.func(*v1.args)
     assert f1 == f1.func(*f1.args)
+
 
 def test_subs():
     assert s1.subs(s1, s2) == s2

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -1,5 +1,5 @@
 from sympy.diffgeom.rn import (
-    R2, R2_p, R2_r, R3_r, R3_c, R3_s, transforms_2d, transforms_3d)
+    R2, R2_p, R2_r, R3_r, R3_c, R3_s)
 from sympy.diffgeom import (Commutator, Differential, TensorProduct,
         WedgeProduct, BaseCovarDerivativeOp, CovarDerivativeOp, LieDerivative,
         covariant_order, contravariant_order, twoform_to_matrix, metric_to_Christoffel_1st,
@@ -21,11 +21,11 @@ def test_R2():
 
     # r**2 = x**2 + y**2
     scalar = (R2.r**2 - R2.x**2 - R2.y**2)
-    scalar = scalar.rcall(point_r, transforms=transforms_2d)
+    scalar = scalar.rcall(point_r)
     assert scalar == trigsimp(scalar) == 0
 
-    scalar = R2.e_r(R2.x**2 + R2.y**2, transforms=transforms_2d)
-    scalar = scalar.rcall(point_p, transforms=transforms_2d)
+    scalar = R2.e_r(R2.x**2 + R2.y**2)
+    scalar = scalar.rcall(point_p)
     assert trigsimp(scalar.doit()) == 2*r0
 
     # polar->rect->polar == Id
@@ -33,28 +33,24 @@ def test_R2():
     m = Matrix([[a], [b]])
     #TODO assert m == R2_r.coord_tuple_transform_to(R2_p, R2_p.coord_tuple_transform_to(R2_r, [a, b])).applyfunc(simplify)
 
-    coord = R2_r.coord_tuple_transform_to(R2_p, m, transforms=transforms_2d)
-    coord = R2_p.coord_tuple_transform_to(
-        R2_r, coord, transforms=transforms_2d)
+    coord = R2_r.coord_tuple_transform_to(R2_p, m)
+    coord = R2_p.coord_tuple_transform_to(R2_r, coord)
     assert m == coord.applyfunc(simplify)
 
 
 def test_R3():
     a, b, c = symbols('a b c', positive=True)
     m = Matrix([[a], [b], [c]])
-    forward = R3_r.coord_tuple_transform_to(R3_c, m, transforms=transforms_3d)
-    backward = R3_c.coord_tuple_transform_to(
-        R3_r, forward, transforms=transforms_3d)
+    forward = R3_r.coord_tuple_transform_to(R3_c, m)
+    backward = R3_c.coord_tuple_transform_to(R3_r, forward)
     assert m == backward.applyfunc(simplify)
     #TODO assert m == R3_r.coord_tuple_transform_to(R3_c, R3_c.coord_tuple_transform_to(R3_r, m)).applyfunc(simplify)
-    forward = R3_r.coord_tuple_transform_to(R3_s, m, transforms=transforms_3d)
-    backward = R3_s.coord_tuple_transform_to(
-        R3_r, forward, transforms=transforms_3d)
+    forward = R3_r.coord_tuple_transform_to(R3_s, m)
+    backward = R3_s.coord_tuple_transform_to(R3_r, forward)
     assert m == backward.applyfunc(simplify)
     #TODO assert m == R3_r.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_r, m)).applyfunc(simplify)
-    forward = R3_c.coord_tuple_transform_to(R3_s, m, transforms=transforms_3d)
-    backward = R3_s.coord_tuple_transform_to(
-        R3_c, forward, transforms=transforms_3d)
+    forward = R3_c.coord_tuple_transform_to(R3_s, m)
+    backward = R3_s.coord_tuple_transform_to(R3_c, forward)
     assert m == backward.applyfunc(simplify)
     #TODO assert m == R3_c.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_c, m)).applyfunc(simplify)
 
@@ -63,10 +59,8 @@ def test_point():
     x, y = symbols('x, y')
     p = R2_r.point([x, y])
     assert p.free_symbols == {x, y}
-    assert p.coords(R2_r, transforms=transforms_2d) == \
-        p.coords() == Matrix([x, y])
-    assert p.coords(R2_p, transforms=transforms_2d) == \
-        Matrix([sqrt(x**2 + y**2), atan2(y, x)])
+    assert p.coords(R2_r) == p.coords() == Matrix([x, y])
+    assert p.coords(R2_p) == Matrix([sqrt(x**2 + y**2), atan2(y, x)])
 
 
 def test_commutator():
@@ -74,8 +68,7 @@ def test_commutator():
     assert Commutator(R2.x*R2.e_x, R2.x*R2.e_x) == 0
     assert Commutator(R2.x*R2.e_x, R2.x*R2.e_y) == R2.x*R2.e_y
     c = Commutator(R2.e_x, R2.e_r)
-    assert c(R2.x, transforms=transforms_2d) == \
-        R2.y*(R2.x**2 + R2.y**2)**(-1)*sin(R2.theta)
+    assert c(R2.x) == R2.y*(R2.x**2 + R2.y**2)**(-1)*sin(R2.theta)
 
 
 def test_differential():
@@ -144,12 +137,12 @@ def test_intcurve_diffequ():
     start_point = R2_r.point([1, 0])
     vector_field = -R2.y*R2.e_x + R2.x*R2.e_y
     equations, init_cond = intcurve_diffequ(
-        vector_field, t, start_point, transforms=transforms_2d)
+        vector_field, t, start_point)
     assert str(equations) == \
         '[f_1(t) + Derivative(f_0(t), t), -f_0(t) + Derivative(f_1(t), t)]'
     assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'
     equations, init_cond = intcurve_diffequ(
-        vector_field, t, start_point, R2_p, transforms=transforms_2d)
+        vector_field, t, start_point, R2_p)
     assert str(
         equations) == '[Derivative(f_0(t), t), Derivative(f_1(t), t) - 1]'
     assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -1,4 +1,5 @@
-from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, R3_c, R3_s
+from sympy.diffgeom.rn import (
+    R2, R2_p, R2_r, R3_r, R3_c, R3_s, transforms_2d, transforms_3d)
 from sympy.diffgeom import (Commutator, Differential, TensorProduct,
         WedgeProduct, BaseCovarDerivativeOp, CovarDerivativeOp, LieDerivative,
         covariant_order, contravariant_order, twoform_to_matrix, metric_to_Christoffel_1st,
@@ -12,56 +13,6 @@ from sympy.testing.pytest import raises, nocache_fail
 
 TP = TensorProduct
 
-from sympy import symbols, Lambda, cos, sin, sqrt, atan2, Matrix, acos
-r, t, p = symbols('r t p')
-x, y, z = symbols('x y z')
-R2_r_R2_p = {
-    R2_p: (
-        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
-        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
-    )
-}
-R2_p_R2_r = {
-    R2_p: (
-        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
-        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
-    )
-}
-
-
-R3_r_tr = {
-    R3_c: (
-        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2), atan2(y, x), z])),
-        Lambda((r, p, z), Matrix([r*cos(p), r*sin(p), z]))
-    ),
-    R3_s: (
-        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2 + z**2), acos(z/sqrt(x**2 + y**2 + z**2)), atan2(y, x)])),
-        Lambda((r, t, p), Matrix([r*sin(t)*cos(p), r*sin(t)*sin(p), r*cos(t)]))
-    )
-}
-
-R3_c_tr = {
-    R3_r: (
-        Lambda((r, p, z), Matrix([r*cos(p), r*sin(p), z])),
-        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2), atan2(y, x), z]))
-    ),
-    R3_s: (
-        Lambda((r, p, z), Matrix([sqrt(r**2 + z**2), acos(z/sqrt(r**2 + z**2)), p])),
-        Lambda((r, t, p), Matrix([r*sin(t), p, r*cos(t)]))
-    )
-}
-
-R3_s_tr = {
-    R3_r: (
-        Lambda((r, t, p), Matrix([r*sin(t)*cos(p), r*sin(t)*sin(p), r*cos(t)])),
-        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2 + z**2), acos(z/sqrt(x**2 + y**2 + z**2)), atan2(y, x)]))
-    ),
-    R3_c: (
-        Lambda((r, t, p), Matrix([r*sin(t), p, r*cos(t)])),
-        Lambda((r, p, z), Matrix([sqrt(r**2 + z**2), acos(z/sqrt(r**2 + z**2)), p]))
-    )
-}
-
 
 def test_R2():
     x0, y0, r0, theta0 = symbols('x0, y0, r0, theta0', real=True)
@@ -70,11 +21,11 @@ def test_R2():
 
     # r**2 = x**2 + y**2
     scalar = (R2.r**2 - R2.x**2 - R2.y**2)
-    scalar = scalar.rcall(point_r, transforms=R2_r_R2_p)
+    scalar = scalar.rcall(point_r, transforms=transforms_2d)
     assert scalar == trigsimp(scalar) == 0
 
-    scalar = R2.e_r(R2.x**2 + R2.y**2, transforms=R2_r_R2_p)
-    scalar = scalar.rcall(point_p, transforms=R2_r_R2_p)
+    scalar = R2.e_r(R2.x**2 + R2.y**2, transforms=transforms_2d)
+    scalar = scalar.rcall(point_p, transforms=transforms_2d)
     assert trigsimp(scalar.doit()) == 2*r0
 
     # polar->rect->polar == Id
@@ -82,22 +33,29 @@ def test_R2():
     m = Matrix([[a], [b]])
     #TODO assert m == R2_r.coord_tuple_transform_to(R2_p, R2_p.coord_tuple_transform_to(R2_r, [a, b])).applyfunc(simplify)
 
-    coord = R2_r.coord_tuple_transform_to(R2_p, m, transforms=R2_r_R2_p)
-    coord = R2_p.coord_tuple_transform_to(R2_r, coord, transforms=R2_r_R2_p)
+    coord = R2_r.coord_tuple_transform_to(R2_p, m, transforms=transforms_2d)
+    coord = R2_p.coord_tuple_transform_to(
+        R2_r, coord, transforms=transforms_2d)
     assert m == coord.applyfunc(simplify)
 
 
 def test_R3():
     a, b, c = symbols('a b c', positive=True)
     m = Matrix([[a], [b], [c]])
-    assert m == R3_c.coord_tuple_transform_to(
-        R3_r, R3_r.coord_tuple_transform_to(R3_c, m, transforms=R3_r_tr), transforms=R3_c_tr).applyfunc(simplify)
+    forward = R3_r.coord_tuple_transform_to(R3_c, m, transforms=transforms_3d)
+    backward = R3_c.coord_tuple_transform_to(
+        R3_r, forward, transforms=transforms_3d)
+    assert m == backward.applyfunc(simplify)
     #TODO assert m == R3_r.coord_tuple_transform_to(R3_c, R3_c.coord_tuple_transform_to(R3_r, m)).applyfunc(simplify)
-    assert m == R3_s.coord_tuple_transform_to(
-        R3_r, R3_r.coord_tuple_transform_to(R3_s, m, transforms=R3_r_tr), transforms=R3_s_tr).applyfunc(simplify)
+    forward = R3_r.coord_tuple_transform_to(R3_s, m, transforms=transforms_3d)
+    backward = R3_s.coord_tuple_transform_to(
+        R3_r, forward, transforms=transforms_3d)
+    assert m == backward.applyfunc(simplify)
     #TODO assert m == R3_r.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_r, m)).applyfunc(simplify)
-    assert m == R3_s.coord_tuple_transform_to(
-        R3_c, R3_c.coord_tuple_transform_to(R3_s, m, transforms=R3_c_tr), transforms=R3_s_tr).applyfunc(simplify)
+    forward = R3_c.coord_tuple_transform_to(R3_s, m, transforms=transforms_3d)
+    backward = R3_s.coord_tuple_transform_to(
+        R3_c, forward, transforms=transforms_3d)
+    assert m == backward.applyfunc(simplify)
     #TODO assert m == R3_c.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_c, m)).applyfunc(simplify)
 
 
@@ -105,8 +63,10 @@ def test_point():
     x, y = symbols('x, y')
     p = R2_r.point([x, y])
     assert p.free_symbols == {x, y}
-    assert p.coords(R2_r, transforms=R2_r_R2_p) == p.coords() == Matrix([x, y])
-    assert p.coords(R2_p, transforms=R2_r_R2_p) == Matrix([sqrt(x**2 + y**2), atan2(y, x)])
+    assert p.coords(R2_r, transforms=transforms_2d) == \
+        p.coords() == Matrix([x, y])
+    assert p.coords(R2_p, transforms=transforms_2d) == \
+        Matrix([sqrt(x**2 + y**2), atan2(y, x)])
 
 
 def test_commutator():
@@ -114,7 +74,8 @@ def test_commutator():
     assert Commutator(R2.x*R2.e_x, R2.x*R2.e_x) == 0
     assert Commutator(R2.x*R2.e_x, R2.x*R2.e_y) == R2.x*R2.e_y
     c = Commutator(R2.e_x, R2.e_r)
-    assert c(R2.x, transforms=R2_r_R2_p) == R2.y*(R2.x**2 + R2.y**2)**(-1)*sin(R2.theta)
+    assert c(R2.x, transforms=transforms_2d) == \
+        R2.y*(R2.x**2 + R2.y**2)**(-1)*sin(R2.theta)
 
 
 def test_differential():
@@ -182,10 +143,13 @@ def test_intcurve_diffequ():
     t = symbols('t')
     start_point = R2_r.point([1, 0])
     vector_field = -R2.y*R2.e_x + R2.x*R2.e_y
-    equations, init_cond = intcurve_diffequ(vector_field, t, start_point, transforms=R2_r_R2_p)
-    assert str(equations) == '[f_1(t) + Derivative(f_0(t), t), -f_0(t) + Derivative(f_1(t), t)]'
+    equations, init_cond = intcurve_diffequ(
+        vector_field, t, start_point, transforms=transforms_2d)
+    assert str(equations) == \
+        '[f_1(t) + Derivative(f_0(t), t), -f_0(t) + Derivative(f_1(t), t)]'
     assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'
-    equations, init_cond = intcurve_diffequ(vector_field, t, start_point, R2_p, transforms=R2_r_R2_p)
+    equations, init_cond = intcurve_diffequ(
+        vector_field, t, start_point, R2_p, transforms=transforms_2d)
     assert str(
         equations) == '[Derivative(f_0(t), t), Derivative(f_1(t), t) - 1]'
     assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -12,6 +12,56 @@ from sympy.testing.pytest import raises, nocache_fail
 
 TP = TensorProduct
 
+from sympy import symbols, Lambda, cos, sin, sqrt, atan2, Matrix, acos
+r, t, p = symbols('r t p')
+x, y, z = symbols('x y z')
+R2_r_R2_p = {
+    R2_p: (
+        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
+        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
+    )
+}
+R2_p_R2_r = {
+    R2_p: (
+        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
+        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
+    )
+}
+
+
+R3_r_tr = {
+    R3_c: (
+        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2), atan2(y, x), z])),
+        Lambda((r, p, z), Matrix([r*cos(p), r*sin(p), z]))
+    ),
+    R3_s: (
+        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2 + z**2), acos(z/sqrt(x**2 + y**2 + z**2)), atan2(y, x)])),
+        Lambda((r, t, p), Matrix([r*sin(t)*cos(p), r*sin(t)*sin(p), r*cos(t)]))
+    )
+}
+
+R3_c_tr = {
+    R3_r: (
+        Lambda((r, p, z), Matrix([r*cos(p), r*sin(p), z])),
+        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2), atan2(y, x), z]))
+    ),
+    R3_s: (
+        Lambda((r, p, z), Matrix([sqrt(r**2 + z**2), acos(z/sqrt(r**2 + z**2)), p])),
+        Lambda((r, t, p), Matrix([r*sin(t), p, r*cos(t)]))
+    )
+}
+
+R3_s_tr = {
+    R3_r: (
+        Lambda((r, t, p), Matrix([r*sin(t)*cos(p), r*sin(t)*sin(p), r*cos(t)])),
+        Lambda((x, y, z), Matrix([sqrt(x**2 + y**2 + z**2), acos(z/sqrt(x**2 + y**2 + z**2)), atan2(y, x)]))
+    ),
+    R3_c: (
+        Lambda((r, t, p), Matrix([r*sin(t), p, r*cos(t)])),
+        Lambda((r, p, z), Matrix([sqrt(r**2 + z**2), acos(z/sqrt(r**2 + z**2)), p]))
+    )
+}
+
 
 def test_R2():
     x0, y0, r0, theta0 = symbols('x0, y0, r0, theta0', real=True)
@@ -19,29 +69,35 @@ def test_R2():
     point_p = R2_p.point([r0, theta0])
 
     # r**2 = x**2 + y**2
-    assert (R2.r**2 - R2.x**2 - R2.y**2).rcall(point_r) == 0
-    assert trigsimp( (R2.r**2 - R2.x**2 - R2.y**2).rcall(point_p) ) == 0
-    assert trigsimp(R2.e_r(R2.x**2 + R2.y**2).rcall(point_p).doit()) == 2*r0
+    scalar = (R2.r**2 - R2.x**2 - R2.y**2)
+    scalar = scalar.rcall(point_r, transforms=R2_r_R2_p)
+    assert scalar == trigsimp(scalar) == 0
+
+    scalar = R2.e_r(R2.x**2 + R2.y**2, transforms=R2_r_R2_p)
+    scalar = scalar.rcall(point_p, transforms=R2_r_R2_p)
+    assert trigsimp(scalar.doit()) == 2*r0
 
     # polar->rect->polar == Id
     a, b = symbols('a b', positive=True)
     m = Matrix([[a], [b]])
     #TODO assert m == R2_r.coord_tuple_transform_to(R2_p, R2_p.coord_tuple_transform_to(R2_r, [a, b])).applyfunc(simplify)
-    assert m == R2_p.coord_tuple_transform_to(
-        R2_r, R2_r.coord_tuple_transform_to(R2_p, m)).applyfunc(simplify)
+
+    coord = R2_r.coord_tuple_transform_to(R2_p, m, transforms=R2_r_R2_p)
+    coord = R2_p.coord_tuple_transform_to(R2_r, coord, transforms=R2_r_R2_p)
+    assert m == coord.applyfunc(simplify)
 
 
 def test_R3():
     a, b, c = symbols('a b c', positive=True)
     m = Matrix([[a], [b], [c]])
     assert m == R3_c.coord_tuple_transform_to(
-        R3_r, R3_r.coord_tuple_transform_to(R3_c, m)).applyfunc(simplify)
+        R3_r, R3_r.coord_tuple_transform_to(R3_c, m, transforms=R3_r_tr), transforms=R3_c_tr).applyfunc(simplify)
     #TODO assert m == R3_r.coord_tuple_transform_to(R3_c, R3_c.coord_tuple_transform_to(R3_r, m)).applyfunc(simplify)
     assert m == R3_s.coord_tuple_transform_to(
-        R3_r, R3_r.coord_tuple_transform_to(R3_s, m)).applyfunc(simplify)
+        R3_r, R3_r.coord_tuple_transform_to(R3_s, m, transforms=R3_r_tr), transforms=R3_s_tr).applyfunc(simplify)
     #TODO assert m == R3_r.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_r, m)).applyfunc(simplify)
     assert m == R3_s.coord_tuple_transform_to(
-        R3_c, R3_c.coord_tuple_transform_to(R3_s, m)).applyfunc(simplify)
+        R3_c, R3_c.coord_tuple_transform_to(R3_s, m, transforms=R3_c_tr), transforms=R3_s_tr).applyfunc(simplify)
     #TODO assert m == R3_c.coord_tuple_transform_to(R3_s, R3_s.coord_tuple_transform_to(R3_c, m)).applyfunc(simplify)
 
 
@@ -49,8 +105,8 @@ def test_point():
     x, y = symbols('x, y')
     p = R2_r.point([x, y])
     assert p.free_symbols == {x, y}
-    assert p.coords(R2_r) == p.coords() == Matrix([x, y])
-    assert p.coords(R2_p) == Matrix([sqrt(x**2 + y**2), atan2(y, x)])
+    assert p.coords(R2_r, transforms=R2_r_R2_p) == p.coords() == Matrix([x, y])
+    assert p.coords(R2_p, transforms=R2_r_R2_p) == Matrix([sqrt(x**2 + y**2), atan2(y, x)])
 
 
 def test_commutator():
@@ -58,7 +114,7 @@ def test_commutator():
     assert Commutator(R2.x*R2.e_x, R2.x*R2.e_x) == 0
     assert Commutator(R2.x*R2.e_x, R2.x*R2.e_y) == R2.x*R2.e_y
     c = Commutator(R2.e_x, R2.e_r)
-    assert c(R2.x) == R2.y*(R2.x**2 + R2.y**2)**(-1)*sin(R2.theta)
+    assert c(R2.x, transforms=R2_r_R2_p) == R2.y*(R2.x**2 + R2.y**2)**(-1)*sin(R2.theta)
 
 
 def test_differential():
@@ -126,10 +182,10 @@ def test_intcurve_diffequ():
     t = symbols('t')
     start_point = R2_r.point([1, 0])
     vector_field = -R2.y*R2.e_x + R2.x*R2.e_y
-    equations, init_cond = intcurve_diffequ(vector_field, t, start_point)
+    equations, init_cond = intcurve_diffequ(vector_field, t, start_point, transforms=R2_r_R2_p)
     assert str(equations) == '[f_1(t) + Derivative(f_0(t), t), -f_0(t) + Derivative(f_1(t), t)]'
     assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'
-    equations, init_cond = intcurve_diffequ(vector_field, t, start_point, R2_p)
+    equations, init_cond = intcurve_diffequ(vector_field, t, start_point, R2_p, transforms=R2_r_R2_p)
     assert str(
         equations) == '[Derivative(f_0(t), t), Derivative(f_1(t), t) - 1]'
     assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'

--- a/sympy/diffgeom/tests/test_function_diffgeom_book.py
+++ b/sympy/diffgeom/tests/test_function_diffgeom_book.py
@@ -1,4 +1,4 @@
-from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r
+from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, transforms_2d
 from sympy.diffgeom import intcurve_series, Differential, WedgeProduct
 from sympy.core import symbols, Function, Derivative
 from sympy.simplify import trigsimp, simplify
@@ -14,53 +14,42 @@ from sympy.matrices import Matrix
 # From "Functional Differential Geometry" as of 2011
 # by Sussman and Wisdom.
 
-from sympy import symbols, Lambda, cos, sin, sqrt, atan2, Matrix
-r, t = symbols('r t')
-x, y = symbols('x y')
-R2_r_R2_p = {
-    R2_p: (
-        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
-        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
-    )
-}
-R2_p_R2_r = {
-    R2_p: (
-        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
-        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
-    )
-}
-
-
 def test_functional_diffgeom_ch2():
     x0, y0, r0, theta0 = symbols('x0, y0, r0, theta0', real=True)
     x, y = symbols('x, y', real=True)
     f = Function('f')
 
-    assert (R2_p.point_to_coords(R2_r.point([x0, y0]), transforms=R2_r_R2_p) ==
-           Matrix([sqrt(x0**2 + y0**2), atan2(y0, x0)]))
-    assert (R2_r.point_to_coords(R2_p.point([r0, theta0]), transforms=R2_r_R2_p) ==
-           Matrix([r0*cos(theta0), r0*sin(theta0)]))
+    p = R2_r.point([x0, y0])
+    assert R2_p.point_to_coords(p, transforms=transforms_2d) == \
+        Matrix([sqrt(x0**2 + y0**2), atan2(y0, x0)])
+    p = R2_p.point([r0, theta0])
+    assert R2_r.point_to_coords(p, transforms=transforms_2d) == \
+        Matrix([r0*cos(theta0), r0*sin(theta0)])
 
-    assert R2_p.jacobian(R2_r, [r0, theta0], transforms=R2_r_R2_p) == Matrix(
-        [[cos(theta0), -r0*sin(theta0)], [sin(theta0), r0*cos(theta0)]])
+    assert R2_p.jacobian(R2_r, [r0, theta0], transforms=transforms_2d) == \
+        Matrix([
+            [cos(theta0), -r0*sin(theta0)],
+            [sin(theta0), r0*cos(theta0)]])
 
     field = f(R2.x, R2.y)
     p1_in_rect = R2_r.point([x0, y0])
     p1_in_polar = R2_p.point([sqrt(x0**2 + y0**2), atan2(y0, x0)])
     assert field.rcall(p1_in_rect) == f(x0, y0)
-    assert field.rcall(p1_in_polar, transforms=R2_r_R2_p) == f(x0, y0)
+    assert field.rcall(p1_in_polar, transforms=transforms_2d) == f(x0, y0)
 
     p_r = R2_r.point([x0, y0])
     p_p = R2_p.point([r0, theta0])
     assert R2.x(p_r) == x0
-    assert R2.x(p_p, transforms=R2_r_R2_p) == r0*cos(theta0)
+    assert R2.x(p_p, transforms=transforms_2d) == r0*cos(theta0)
     assert R2.r(p_p) == r0
-    assert R2.r(p_r, transforms=R2_r_R2_p) == sqrt(x0**2 + y0**2)
-    assert R2.theta(p_r, transforms=R2_r_R2_p) == atan2(y0, x0)
+    assert R2.r(p_r, transforms=transforms_2d) == sqrt(x0**2 + y0**2)
+    assert R2.theta(p_r, transforms=transforms_2d) == atan2(y0, x0)
 
     h = R2.x*R2.r**2 + R2.y**3
-    assert h.rcall(p_r, transforms=R2_r_R2_p) == x0*(x0**2 + y0**2) + y0**3
-    assert h.rcall(p_p, transforms=R2_r_R2_p) == r0**3*sin(theta0)**3 + r0**3*cos(theta0)
+    assert h.rcall(p_r, transforms=transforms_2d) == \
+        x0*(x0**2 + y0**2) + y0**3
+    assert h.rcall(p_p, transforms=transforms_2d) == \
+        r0**3*sin(theta0)**3 + r0**3*cos(theta0)
 
 
 def test_functional_diffgeom_ch3():
@@ -76,10 +65,10 @@ def test_functional_diffgeom_ch3():
     assert v_field.rcall(s_field).rcall(p_r).doit() == b1(
         x0)*Derivative(f(x0, y0), x0) + b2(y0)*Derivative(f(x0, y0), y0)
 
-    assert R2.e_x(R2.r**2, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == 2*x0
-    v = R2.e_x + 2*R2.e_y
-    s = R2.r**2 + 3*R2.x
-    assert v.rcall(s, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p).doit() == 2*x0 + 4*y0 + 3
+    v = R2.e_x(R2.r**2, transforms=transforms_2d)
+    assert v.rcall(p_r, transforms=transforms_2d) == 2*x0
+    v = (R2.e_x + 2*R2.e_y).rcall(R2.r**2 + 3*R2.x, transforms=transforms_2d)
+    assert v.rcall(p_r, transforms=transforms_2d).doit() == 2*x0 + 4*y0 + 3
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
     series = intcurve_series(circ, t, R2_r.point([1, 0]), coeffs=True)
@@ -111,10 +100,12 @@ def test_functional_diffgeom_ch4():
 
     s_field_p = f(R2.r, R2.theta)
     df = Differential(s_field_p)
-    assert trigsimp(df(R2.e_x, transforms=R2_r_R2_p).rcall(p_p, transforms=R2_r_R2_p).doit()) == (
+    df_e_x = df(R2.e_x, transforms=transforms_2d)
+    assert trigsimp(df_e_x.rcall(p_p, transforms=transforms_2d).doit()) == (
         cos(theta0)*Derivative(f(r0, theta0), r0) -
         sin(theta0)*Derivative(f(r0, theta0), theta0)/r0)
-    assert trigsimp(df(R2.e_y, transforms=R2_r_R2_p).rcall(p_p, transforms=R2_r_R2_p).doit()) == (
+    df_e_y = df(R2.e_y, transforms=transforms_2d)
+    assert trigsimp(df_e_y.rcall(p_p, transforms=transforms_2d).doit()) == (
         sin(theta0)*Derivative(f(r0, theta0), r0) +
         cos(theta0)*Derivative(f(r0, theta0), theta0)/r0)
 
@@ -124,12 +115,17 @@ def test_functional_diffgeom_ch4():
     assert R2.dx(R2.e_y) == 0
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
-    assert R2.dx(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p).doit() == -y0
-    assert R2.dy(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == x0
-    assert R2.dr(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == 0
-    assert simplify(R2.dtheta(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p)) == 1
+    dx_circ = R2.dx(circ, transforms=transforms_2d)
+    assert dx_circ.rcall(p_r, transforms=transforms_2d).doit() == -y0
+    dy_circ = R2.dy(circ, transforms=transforms_2d)
+    assert dy_circ.rcall(p_r, transforms=transforms_2d) == x0
+    dr_circ = R2.dr(circ, transforms=transforms_2d)
+    assert dr_circ.rcall(p_r, transforms=transforms_2d) == 0
+    dt_circ = R2.dtheta(circ, transforms=transforms_2d)
+    assert simplify(dt_circ.rcall(p_r, transforms=transforms_2d)) == 1
 
-    assert (circ - R2.e_theta).rcall(s_field_r, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == 0
+    new = (circ - R2.e_theta).rcall(s_field_r, transforms=transforms_2d)
+    assert new.rcall(p_r, transforms=transforms_2d) == 0
 
 
 def test_functional_diffgeom_ch6():

--- a/sympy/diffgeom/tests/test_function_diffgeom_book.py
+++ b/sympy/diffgeom/tests/test_function_diffgeom_book.py
@@ -14,37 +14,53 @@ from sympy.matrices import Matrix
 # From "Functional Differential Geometry" as of 2011
 # by Sussman and Wisdom.
 
+from sympy import symbols, Lambda, cos, sin, sqrt, atan2, Matrix
+r, t = symbols('r t')
+x, y = symbols('x y')
+R2_r_R2_p = {
+    R2_p: (
+        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
+        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
+    )
+}
+R2_p_R2_r = {
+    R2_p: (
+        Lambda((x, y), Matrix([sqrt(x**2 + y**2), atan2(y, x)])),
+        Lambda((r, t), Matrix([r*cos(t), r*sin(t)]))
+    )
+}
+
 
 def test_functional_diffgeom_ch2():
     x0, y0, r0, theta0 = symbols('x0, y0, r0, theta0', real=True)
     x, y = symbols('x, y', real=True)
     f = Function('f')
 
-    assert (R2_p.point_to_coords(R2_r.point([x0, y0])) ==
+    assert (R2_p.point_to_coords(R2_r.point([x0, y0]), transforms=R2_r_R2_p) ==
            Matrix([sqrt(x0**2 + y0**2), atan2(y0, x0)]))
-    assert (R2_r.point_to_coords(R2_p.point([r0, theta0])) ==
+    assert (R2_r.point_to_coords(R2_p.point([r0, theta0]), transforms=R2_r_R2_p) ==
            Matrix([r0*cos(theta0), r0*sin(theta0)]))
 
-    assert R2_p.jacobian(R2_r, [r0, theta0]) == Matrix(
+    assert R2_p.jacobian(R2_r, [r0, theta0], transforms=R2_r_R2_p) == Matrix(
         [[cos(theta0), -r0*sin(theta0)], [sin(theta0), r0*cos(theta0)]])
 
     field = f(R2.x, R2.y)
     p1_in_rect = R2_r.point([x0, y0])
     p1_in_polar = R2_p.point([sqrt(x0**2 + y0**2), atan2(y0, x0)])
     assert field.rcall(p1_in_rect) == f(x0, y0)
-    assert field.rcall(p1_in_polar) == f(x0, y0)
+    assert field.rcall(p1_in_polar, transforms=R2_r_R2_p) == f(x0, y0)
 
     p_r = R2_r.point([x0, y0])
     p_p = R2_p.point([r0, theta0])
     assert R2.x(p_r) == x0
-    assert R2.x(p_p) == r0*cos(theta0)
+    assert R2.x(p_p, transforms=R2_r_R2_p) == r0*cos(theta0)
     assert R2.r(p_p) == r0
-    assert R2.r(p_r) == sqrt(x0**2 + y0**2)
-    assert R2.theta(p_r) == atan2(y0, x0)
+    assert R2.r(p_r, transforms=R2_r_R2_p) == sqrt(x0**2 + y0**2)
+    assert R2.theta(p_r, transforms=R2_r_R2_p) == atan2(y0, x0)
 
     h = R2.x*R2.r**2 + R2.y**3
-    assert h.rcall(p_r) == x0*(x0**2 + y0**2) + y0**3
-    assert h.rcall(p_p) == r0**3*sin(theta0)**3 + r0**3*cos(theta0)
+    assert h.rcall(p_r, transforms=R2_r_R2_p) == x0*(x0**2 + y0**2) + y0**3
+    assert h.rcall(p_p, transforms=R2_r_R2_p) == r0**3*sin(theta0)**3 + r0**3*cos(theta0)
 
 
 def test_functional_diffgeom_ch3():
@@ -60,10 +76,10 @@ def test_functional_diffgeom_ch3():
     assert v_field.rcall(s_field).rcall(p_r).doit() == b1(
         x0)*Derivative(f(x0, y0), x0) + b2(y0)*Derivative(f(x0, y0), y0)
 
-    assert R2.e_x(R2.r**2).rcall(p_r) == 2*x0
+    assert R2.e_x(R2.r**2, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == 2*x0
     v = R2.e_x + 2*R2.e_y
     s = R2.r**2 + 3*R2.x
-    assert v.rcall(s).rcall(p_r).doit() == 2*x0 + 4*y0 + 3
+    assert v.rcall(s, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p).doit() == 2*x0 + 4*y0 + 3
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
     series = intcurve_series(circ, t, R2_r.point([1, 0]), coeffs=True)
@@ -95,10 +111,10 @@ def test_functional_diffgeom_ch4():
 
     s_field_p = f(R2.r, R2.theta)
     df = Differential(s_field_p)
-    assert trigsimp(df(R2.e_x).rcall(p_p).doit()) == (
+    assert trigsimp(df(R2.e_x, transforms=R2_r_R2_p).rcall(p_p, transforms=R2_r_R2_p).doit()) == (
         cos(theta0)*Derivative(f(r0, theta0), r0) -
         sin(theta0)*Derivative(f(r0, theta0), theta0)/r0)
-    assert trigsimp(df(R2.e_y).rcall(p_p).doit()) == (
+    assert trigsimp(df(R2.e_y, transforms=R2_r_R2_p).rcall(p_p, transforms=R2_r_R2_p).doit()) == (
         sin(theta0)*Derivative(f(r0, theta0), r0) +
         cos(theta0)*Derivative(f(r0, theta0), theta0)/r0)
 
@@ -108,12 +124,12 @@ def test_functional_diffgeom_ch4():
     assert R2.dx(R2.e_y) == 0
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
-    assert R2.dx(circ).rcall(p_r).doit() == -y0
-    assert R2.dy(circ).rcall(p_r) == x0
-    assert R2.dr(circ).rcall(p_r) == 0
-    assert simplify(R2.dtheta(circ).rcall(p_r)) == 1
+    assert R2.dx(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p).doit() == -y0
+    assert R2.dy(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == x0
+    assert R2.dr(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == 0
+    assert simplify(R2.dtheta(circ, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p)) == 1
 
-    assert (circ - R2.e_theta).rcall(s_field_r).rcall(p_r) == 0
+    assert (circ - R2.e_theta).rcall(s_field_r, transforms=R2_r_R2_p).rcall(p_r, transforms=R2_r_R2_p) == 0
 
 
 def test_functional_diffgeom_ch6():

--- a/sympy/diffgeom/tests/test_function_diffgeom_book.py
+++ b/sympy/diffgeom/tests/test_function_diffgeom_book.py
@@ -1,4 +1,4 @@
-from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, transforms_2d
+from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r
 from sympy.diffgeom import intcurve_series, Differential, WedgeProduct
 from sympy.core import symbols, Function, Derivative
 from sympy.simplify import trigsimp, simplify
@@ -20,13 +20,13 @@ def test_functional_diffgeom_ch2():
     f = Function('f')
 
     p = R2_r.point([x0, y0])
-    assert R2_p.point_to_coords(p, transforms=transforms_2d) == \
+    assert R2_p.point_to_coords(p) == \
         Matrix([sqrt(x0**2 + y0**2), atan2(y0, x0)])
     p = R2_p.point([r0, theta0])
-    assert R2_r.point_to_coords(p, transforms=transforms_2d) == \
+    assert R2_r.point_to_coords(p) == \
         Matrix([r0*cos(theta0), r0*sin(theta0)])
 
-    assert R2_p.jacobian(R2_r, [r0, theta0], transforms=transforms_2d) == \
+    assert R2_p.jacobian(R2_r, [r0, theta0]) == \
         Matrix([
             [cos(theta0), -r0*sin(theta0)],
             [sin(theta0), r0*cos(theta0)]])
@@ -35,21 +35,19 @@ def test_functional_diffgeom_ch2():
     p1_in_rect = R2_r.point([x0, y0])
     p1_in_polar = R2_p.point([sqrt(x0**2 + y0**2), atan2(y0, x0)])
     assert field.rcall(p1_in_rect) == f(x0, y0)
-    assert field.rcall(p1_in_polar, transforms=transforms_2d) == f(x0, y0)
+    assert field.rcall(p1_in_polar) == f(x0, y0)
 
     p_r = R2_r.point([x0, y0])
     p_p = R2_p.point([r0, theta0])
     assert R2.x(p_r) == x0
-    assert R2.x(p_p, transforms=transforms_2d) == r0*cos(theta0)
+    assert R2.x(p_p) == r0*cos(theta0)
     assert R2.r(p_p) == r0
-    assert R2.r(p_r, transforms=transforms_2d) == sqrt(x0**2 + y0**2)
-    assert R2.theta(p_r, transforms=transforms_2d) == atan2(y0, x0)
+    assert R2.r(p_r) == sqrt(x0**2 + y0**2)
+    assert R2.theta(p_r) == atan2(y0, x0)
 
     h = R2.x*R2.r**2 + R2.y**3
-    assert h.rcall(p_r, transforms=transforms_2d) == \
-        x0*(x0**2 + y0**2) + y0**3
-    assert h.rcall(p_p, transforms=transforms_2d) == \
-        r0**3*sin(theta0)**3 + r0**3*cos(theta0)
+    assert h.rcall(p_r) == x0*(x0**2 + y0**2) + y0**3
+    assert h.rcall(p_p) == r0**3*sin(theta0)**3 + r0**3*cos(theta0)
 
 
 def test_functional_diffgeom_ch3():
@@ -65,10 +63,10 @@ def test_functional_diffgeom_ch3():
     assert v_field.rcall(s_field).rcall(p_r).doit() == b1(
         x0)*Derivative(f(x0, y0), x0) + b2(y0)*Derivative(f(x0, y0), y0)
 
-    v = R2.e_x(R2.r**2, transforms=transforms_2d)
-    assert v.rcall(p_r, transforms=transforms_2d) == 2*x0
-    v = (R2.e_x + 2*R2.e_y).rcall(R2.r**2 + 3*R2.x, transforms=transforms_2d)
-    assert v.rcall(p_r, transforms=transforms_2d).doit() == 2*x0 + 4*y0 + 3
+    v = R2.e_x(R2.r**2)
+    assert v.rcall(p_r) == 2*x0
+    v = (R2.e_x + 2*R2.e_y).rcall(R2.r**2 + 3*R2.x)
+    assert v.rcall(p_r).doit() == 2*x0 + 4*y0 + 3
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
     series = intcurve_series(circ, t, R2_r.point([1, 0]), coeffs=True)
@@ -100,12 +98,12 @@ def test_functional_diffgeom_ch4():
 
     s_field_p = f(R2.r, R2.theta)
     df = Differential(s_field_p)
-    df_e_x = df(R2.e_x, transforms=transforms_2d)
-    assert trigsimp(df_e_x.rcall(p_p, transforms=transforms_2d).doit()) == (
+    df_e_x = df(R2.e_x)
+    assert trigsimp(df_e_x.rcall(p_p).doit()) == (
         cos(theta0)*Derivative(f(r0, theta0), r0) -
         sin(theta0)*Derivative(f(r0, theta0), theta0)/r0)
-    df_e_y = df(R2.e_y, transforms=transforms_2d)
-    assert trigsimp(df_e_y.rcall(p_p, transforms=transforms_2d).doit()) == (
+    df_e_y = df(R2.e_y)
+    assert trigsimp(df_e_y.rcall(p_p).doit()) == (
         sin(theta0)*Derivative(f(r0, theta0), r0) +
         cos(theta0)*Derivative(f(r0, theta0), theta0)/r0)
 
@@ -115,17 +113,17 @@ def test_functional_diffgeom_ch4():
     assert R2.dx(R2.e_y) == 0
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
-    dx_circ = R2.dx(circ, transforms=transforms_2d)
-    assert dx_circ.rcall(p_r, transforms=transforms_2d).doit() == -y0
-    dy_circ = R2.dy(circ, transforms=transforms_2d)
-    assert dy_circ.rcall(p_r, transforms=transforms_2d) == x0
-    dr_circ = R2.dr(circ, transforms=transforms_2d)
-    assert dr_circ.rcall(p_r, transforms=transforms_2d) == 0
-    dt_circ = R2.dtheta(circ, transforms=transforms_2d)
-    assert simplify(dt_circ.rcall(p_r, transforms=transforms_2d)) == 1
+    dx_circ = R2.dx(circ)
+    assert dx_circ.rcall(p_r).doit() == -y0
+    dy_circ = R2.dy(circ)
+    assert dy_circ.rcall(p_r) == x0
+    dr_circ = R2.dr(circ)
+    assert dr_circ.rcall(p_r) == 0
+    dt_circ = R2.dtheta(circ)
+    assert simplify(dt_circ.rcall(p_r)) == 1
 
-    new = (circ - R2.e_theta).rcall(s_field_r, transforms=transforms_2d)
-    assert new.rcall(p_r, transforms=transforms_2d) == 0
+    new = (circ - R2.e_theta).rcall(s_field_r)
+    assert new.rcall(p_r) == 0
 
 
 def test_functional_diffgeom_ch6():

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -342,8 +342,7 @@ class ReprPrinter(Printer):
         name = self._print(coords.name)
         patch = self._print(coords.patch)
         names = self._print(coords._names)
-        transforms = self._print(coords.transform_dict)
-        return "%s(%s, %s, %s, %s)" % (class_name, name, patch, names, transforms)
+        return "%s(%s, %s, %s)" % (class_name, name, patch, names)
 
     def _print_BaseScalarField(self, bsf):
         class_name = bsf.func.__name__

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -311,13 +311,13 @@ def test_Permutation():
 def test_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
     m = Manifold('M', 2)
-    assert srepr(m) == "Manifold('M', 2)"
+    assert srepr(m) == "Manifold('M', Integer(2))"
     p = Patch('P', m)
-    assert srepr(p) == "Patch('P', Manifold('M', 2))"
+    assert srepr(p) == "Patch('P', Manifold('M', Integer(2)))"
     rect = CoordSystem('rect', p)
-    assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1'), Dict())"
+    assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', Integer(2))), ('rect_0', 'rect_1'))"
     b = BaseScalarField(rect, 0)
-    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1'), Dict()), Integer(0))"
+    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', Integer(2))), ('rect_0', 'rect_1')), Integer(0))"
 
 def test_dict():
     from sympy import srepr

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -244,6 +244,17 @@ def test_geometry():
             RegularPolygon(p1, 4, 5), Triangle, Triangle(p1, p2, p3)):
         check(c, check_attr=False)
 
+#================== diffgeom ====================
+from sympy.diffgeom.diffgeom import Manifold, Patch, CoordSystem
+def test_diffgeom():
+    manifold = Manifold('M', 2)
+    check(manifold)
+    patch = Patch('P', manifold)
+    check(patch)
+    coordsys = CoordSystem('C', patch, ['x', 'y'])
+    check(coordsys)
+
+
 #================== integrals ====================
 from sympy.integrals.integrals import Integral
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/pull/19368

#### Brief description of what is fixed or changed

- I've changed the format of `transforms` dict to have keys and values like `(from, to) : Lambda`, so it will look more easy to use directed graph edges.
- I've allowed `rcall` to pass keyword arguments.
- I've fixed pickling issues by wrapping the objects in `Basic` and reverted `Atom`. 
There can be other ways to use `getnewargs`, but it's better to wrap objects with `Basic`  and make them invariant under `obj.func(*args)`.
I've made the names to store as `Dummy` to disable substitution with symbols with same names.
- Now, some methods that had relied on coordinate transformations may accept `transforms` as an optional keyword argument, but I've also allowed it to look up for `transforms_2d` and `transforms_3d` when possible, to make it convenient for common usage examples like rectangular, polar, or spherical coordinate systems,

I've tested it locally, but if there are any problems with tests, let me know.

#### Other comments


#### Release Notes
