### PR TITLE
Allow refine for boolean functions

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -179,6 +179,10 @@ class Boolean(Basic):
                            if i.is_Boolean or i.is_Symbol
                            or isinstance(i, (Eq, Ne))])
 
+    def refine(self, assumptions):
+        from sympy.assumptions import refine
+        return refine(self, assumptions)
+
 
 class BooleanAtom(Boolean):
     """
@@ -645,6 +649,18 @@ class BooleanFunction(Application, Boolean):
         rv = rv.func(*([_canonical(i) for i in ordered(Rel)]
                      + nonRel + nonRealRel))
         return rv
+
+    def _eval_refine(self, assumptions):
+        from sympy.assumptions import ask, refine
+        args = []
+        for a in self.args:
+            refined_a = refine(a, assumptions)
+            evaluated_a = ask(refined_a, assumptions)
+            if evaluated_a is None:
+                args.append(refined_a)
+            else:
+                args.append(evaluated_a)
+        return self.func(*args)
 
 
 class And(LatticeOp, BooleanFunction):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,4 +1,5 @@
 from sympy.assumptions.ask import Q
+from sympy.assumptions.refine import refine
 from sympy.core.numbers import oo
 from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.singleton import S
@@ -1191,3 +1192,7 @@ def test_bool_monomial():
     x, y = symbols('x,y')
     assert bool_monomial(1, [x, y]) == y
     assert bool_monomial([1, 1], [x, y]) == And(x, y)
+
+
+def test_refine():
+    assert refine(Or(Q.eq(x, 1), Q.eq(x, -1)), Q.positive(x)) == Q.eq(x, 1)

--- a/sympy/relation/binrel.py
+++ b/sympy/relation/binrel.py
@@ -37,7 +37,7 @@ class BinaryRelation(Predicate):
         if ret is not None:
             return ret
 
-        # definitive comparison with 0
+        # definitive comparison with 0 if lhs-rhs is number
         try:
             dif = lhs - rhs
             v = None

--- a/sympy/relation/equality.py
+++ b/sympy/relation/equality.py
@@ -50,9 +50,7 @@ class Equal(BinaryRelation):
         # Go through the equality logic.
         # If expressions have the same structure, they must be equal.
         lhs, rhs = args
-        if all(isinstance(i, BooleanAtom) for i in (rhs, lhs)):
-            return False  # True != False
-        elif not (lhs.is_Symbol or rhs.is_Symbol) and (
+        if not (lhs.is_Symbol or rhs.is_Symbol) and (
             isinstance(lhs, Boolean) !=
             isinstance(rhs, Boolean)):
             return False  # only Booleans can equal Booleans

--- a/sympy/relation/handlers/equality.py
+++ b/sympy/relation/handlers/equality.py
@@ -1,5 +1,6 @@
 from sympy.assumptions import ask, Q
 from sympy.core import Basic, Expr, Symbol, Tuple
+from sympy.core.kind import NumberKind
 from sympy.core.function import AppliedUndef
 from sympy.core.logic import fuzzy_bool, fuzzy_and
 from sympy.logic.boolalg import BooleanAtom
@@ -38,3 +39,15 @@ def _(lhs, rhs, assumptions):
 @EqualHandler.register(BooleanAtom, BooleanAtom)
 def _(lhs, rhs, assumptions):
     return lhs is rhs
+
+@EqualHandler.register(Expr, Expr)
+def _(lhs, rhs, assumptions):
+    try:
+        diff = lhs - rhs
+        if diff.kind is NumberKind:
+            ret = ask(Q.zero(diff), assumptions)
+            if ret is not None:
+                return ret
+    except TypeError:
+        pass
+    return None

--- a/sympy/relation/tests/test_equality.py
+++ b/sympy/relation/tests/test_equality.py
@@ -118,6 +118,8 @@ def test_ask():
 
     assert ask(Q.eq(log(cos(2)**2 + sin(2)**2), 0)) is True
 
+    assert ask(Q.eq(x, 1), Q.negative(x)) is False
+
 def test_reversed():
     assert Q.eq(x, y).reversed == Q.eq(y, x)
 


### PR DESCRIPTION
Dispatcher for Q.eq is enhanced as well.

This makes Q.eq(x**2, 1).solve(x).refine(Q.positive(x)) return Q.eq(x,1).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->